### PR TITLE
Memories of a broken dimension

### DIFF
--- a/probe/Cargo.toml
+++ b/probe/Cargo.toml
@@ -18,4 +18,4 @@ num_cpus = "1.12.0"
 thiserror = "1.0.13"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.3"
+winapi = { version = "0.3", features = ["psapi", "processthreadsapi"]}

--- a/probe/src/windows.rs
+++ b/probe/src/windows.rs
@@ -2,12 +2,15 @@ use std::time::Duration;
 
 use winapi::shared::minwindef::FILETIME;
 use winapi::um::processthreadsapi::{GetCurrentProcess, GetProcessTimes};
+use winapi::um::psapi::{GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS_EX};
 
 use super::{OsReadings, ReadingsResult};
 
 pub(crate) fn get_os_readings() -> ReadingsResult<OsReadings> {
     unsafe {
         let h_process = GetCurrentProcess();
+
+        // Query timers information
         let mut creation_time: FILETIME = std::mem::zeroed();
         let mut exit_time: FILETIME = std::mem::zeroed();
         let mut kernel_time: FILETIME = std::mem::zeroed();
@@ -26,14 +29,27 @@ pub(crate) fn get_os_readings() -> ReadingsResult<OsReadings> {
             (user_time.dwHighDateTime as u32 as u64) << 32 + user_time.dwLowDateTime as u64;
         let user_time = Duration::from_nanos(user_time * 100);
 
+        // Query memory information
+        let mut mem_counters: PROCESS_MEMORY_COUNTERS_EX = std::mem::zeroed();
+        GetProcessMemoryInfo(
+            h_process,
+            &mut mem_counters as *mut PROCESS_MEMORY_COUNTERS_EX as *mut _,
+            std::mem::size_of::<PROCESS_MEMORY_COUNTERS_EX>() as u32,
+        );
+
+        let virtual_size = mem_counters.PrivateUsage as u64;
+        let resident_size = mem_counters.WorkingSetSize as u64;
+        let resident_size_max = mem_counters.PeakWorkingSetSize as u64;
+        let major_fault = mem_counters.PageFaultCount as u64;
+
         let usage = OsReadings {
-            virtual_size: 0,
-            resident_size: 0,
-            resident_size_max: 0,
+            virtual_size,
+            resident_size,
+            resident_size_max,
             user_time,
             system_time,
             minor_fault: 0,
-            major_fault: 0,
+            major_fault,
         };
 
         Ok(usage)

--- a/probe/src/windows.rs
+++ b/probe/src/windows.rs
@@ -23,10 +23,9 @@ pub(crate) fn get_os_readings() -> ReadingsResult<OsReadings> {
             &mut user_time,
         );
         let system_time =
-            (kernel_time.dwHighDateTime as u32 as u64) << 32 + kernel_time.dwLowDateTime as u64;
+            ((kernel_time.dwHighDateTime as u64) << 32) + kernel_time.dwLowDateTime as u64;
         let system_time = Duration::from_nanos(system_time * 100);
-        let user_time =
-            (user_time.dwHighDateTime as u32 as u64) << 32 + user_time.dwLowDateTime as u64;
+        let user_time = ((user_time.dwHighDateTime as u64) << 32) + user_time.dwLowDateTime as u64;
         let user_time = Duration::from_nanos(user_time * 100);
 
         // Query memory information


### PR DESCRIPTION
This PR adds tentative support for querying memory counters on win32. It also fixes the "weird shift left overflow errors" we've been getting.

Having never worked with the win32 API, I'm not at all confident that the mappings to unix concepts are correct, for either the virtual/resident memory usage (probably not -- edit: the vsz is now dropped as it seemed weird) or the page fault counts (of which there seems to be only 1 type instead of the expected 2).

It seems to get some information out at least :)

Here are the `readings.out` of the `simple` example (which now completes successfully whereas it used to fail due to the overflow):
```
#ReadingsV1
   time cor        vsz        rsz     rszmax    utime    stime       minf       majf      alloc       free       done event
  0.000   8          0    2281472    2285568 0.000000 0.000000        597          0       8930        328          0 spawned_heartbeat
  1.007   8          0    2330624    2334720 0.000000 0.000000        610          0       9256        415          0 
  2.007   8          0    2342912    2347008 0.000000 0.000000        613          0       9256        415          0 
  3.000   8          0    2347008    2351104 0.000000 0.000000        614          0     809256        415          0 
  4.007   8          0    3145728    3149824 0.000000 0.000000        809          0     809280        415          0 
  5.001   8          0    3145728    3149824 0.000000 0.000000        809          0     809280        415          0 
  6.014   8          0    3158016    3162112 0.000000 0.000000        812          0    1609280        415          0 
  7.014   8          0    3952640    3956736 0.015625 0.000000       1006          0    1609328        439          1 
  8.014   8          0    3952640    3956736 0.015625 0.000000       1006          0    1609328        439          1 
  9.014   8          0    3952640    3956736 0.015625 0.000000       1006          0    1609328        439          1 
 10.015   8          0    4759552    4763648 0.015625 0.000000       1204          0    2409424        487          2 
 11.015   8          0    4759552    4763648 0.015625 0.000000       1204          0    2409424        487          2 
 12.015   8          0    4759552    4763648 0.015625 0.000000       1204          0    2409424        487          2 
 13.015   8          0    5558272    5562368 0.031250 0.000000       1399          0    3209424        487          3 
 14.015   8          0    5558272    5562368 0.031250 0.000000       1399          0    3209424        487          3 
 15.001   8          0    5558272    5562368 0.031250 0.000000       1399          0    3209424        487          3 
 15.086   8          0    6365184    6369280 0.031250 0.000000       1597          0    4009691        618          4 about_to_drop_buffers
 15.086   8          0    3174400    6373376 0.031250 0.000000       1598          0    4009695    4000850          4 done

```

_I'll be looking forward to my royalty check in the mail._